### PR TITLE
some improvements to epoll-shim/libinput/libudev-devd ports

### DIFF
--- a/wayland/libepoll-shim/Makefile
+++ b/wayland/libepoll-shim/Makefile
@@ -1,8 +1,8 @@
 # Created by yohanesu75@gmail.com
 # $FreeBSD$
 
-PORTNAME= libepoll-shim
-PORTVERSION= 0.1
+PORTNAME=	libepoll-shim
+PORTVERSION=	0.0.20160812
 CATEGORIES=	wayland
 
 MAINTAINER=	x11@FreeBSD.org
@@ -11,22 +11,14 @@ COMMENT=	epoll shim implemented using kevent
 USE_GITHUB=	yes
 GH_ACCOUNT=	jiixyj
 GH_PROJECT=	epoll-shim
-GH_TAGNAME=	b2de08a
+GH_TAGNAME=	0562794
 
-USE_LDCONFIG= yes
+USE_LDCONFIG=	yes
 
-# TODO: Use automatic installer (make).
-# Problem: Installs to /usr/lib. How to set correct install folder?
-do-install:
-	${MKDIR} ${STAGEDIR}${PREFIX}/include/sys
-	${INSTALL_DATA} ${WRKSRC}/include/sys/epoll.h ${STAGEDIR}${PREFIX}/include/sys/epoll.h
-	${INSTALL_DATA} ${WRKSRC}/include/sys/signalfd.h ${STAGEDIR}${PREFIX}/include/sys/signalfd.h
-	${INSTALL_DATA} ${WRKSRC}/include/sys/timerfd.h ${STAGEDIR}${PREFIX}/include/sys/timerfd.h
-	${INSTALL_LIB} ${WRKSRC}/libepoll-shim.a ${STAGEDIR}${PREFIX}/lib/
-	${INSTALL_LIB} ${WRKSRC}/libepoll-shim.so.0 ${STAGEDIR}${PREFIX}/lib/
-	${LN} -sf libepoll-shim.so.0 ${STAGEDIR}${PREFIX}/lib/libepoll-shim.so
+USES=		uidfix
+MAKE_ARGS=	LIBDIR=${PREFIX}/lib INCLUDEDIR=${PREFIX}/include
 
-post-install:
-	${STRIP_CMD} ${STAGEDIR}${PREFIX}/lib/libepoll-shim.so.0
+pre-install:
+	@${MKDIR} ${STAGEDIR}/${PREFIX}/include/libepoll-shim/sys
 
 .include <bsd.port.mk>

--- a/wayland/libepoll-shim/distinfo
+++ b/wayland/libepoll-shim/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1471398672
-SHA256 (jiixyj-epoll-shim-0.1-b2de08a_GH0.tar.gz) = 21d83d65cf095809a8c23aea6684225fda4d1b86bd49db994f16961c0dc3e790
-SIZE (jiixyj-epoll-shim-0.1-b2de08a_GH0.tar.gz) = 7024
+TIMESTAMP = 1471729209
+SHA256 (jiixyj-epoll-shim-0.0.20160812-0562794_GH0.tar.gz) = 32f924a257af617687855f438b9b6cac870037c811f09c2ab1d7195f35c31805
+SIZE (jiixyj-epoll-shim-0.0.20160812-0562794_GH0.tar.gz) = 7031

--- a/wayland/libepoll-shim/pkg-plist
+++ b/wayland/libepoll-shim/pkg-plist
@@ -1,6 +1,6 @@
-include/sys/epoll.h
-include/sys/signalfd.h
-include/sys/timerfd.h
+include/libepoll-shim/sys/epoll.h
+include/libepoll-shim/sys/signalfd.h
+include/libepoll-shim/sys/timerfd.h
 lib/libepoll-shim.a
 lib/libepoll-shim.so
 lib/libepoll-shim.so.0

--- a/wayland/libinput/Makefile
+++ b/wayland/libinput/Makefile
@@ -21,7 +21,7 @@ USES=		autoreconf gmake libtool pathfix pkgconfig
 GNU_CONFIGURE=	yes
 PATHFIX_MAKEFILEIN?=	Makefile.am
 
-CPPFLAGS+=	-I${LOCALBASE}/include
+CPPFLAGS+=	-I${LOCALBASE}/include/libepoll-shim
 INSTALL_TARGET=	install-strip
 
 .include <bsd.port.mk>

--- a/wayland/libudev-devd/files/patch-Makefile.am
+++ b/wayland/libudev-devd/files/patch-Makefile.am
@@ -1,0 +1,9 @@
+--- Makefile.am.orig	2015-11-10 19:56:22 UTC
++++ Makefile.am
+@@ -22,5 +22,5 @@ libudev_la_LDFLAGS =	-pthread
+ libudev_la_CFLAGS =	-I$(top_srcdir) -fvisibility=hidden	\
+ 			$(LIBEVDEV_CFLAGS)
+ 
+-pkgconfigdir = $(libdir)/pkgconfig
++pkgconfigdir = $(prefix)/libdata/pkgconfig
+ pkgconfig_DATA = libudev.pc

--- a/wayland/libudev-devd/pkg-plist
+++ b/wayland/libudev-devd/pkg-plist
@@ -2,4 +2,4 @@ include/libudev.h
 lib/libudev.so
 lib/libudev.so.0
 lib/libudev.so.0.0.0
-lib/pkgconfig/libudev.pc
+libdata/pkgconfig/libudev.pc


### PR DESCRIPTION
Hi,
I've modified the epoll-shim port so that the Makefile is used for installing. Also, the headers are now installed into "include/libepoll-shim/sys" to minimize conflicts with other libraries.
The pkgconfig file of libdevd-udev wasn't picked up correctly (wrong install dir?).